### PR TITLE
More secure SQLAlchemy queries

### DIFF
--- a/keystone_scim/__init__.py
+++ b/keystone_scim/__init__.py
@@ -5,7 +5,7 @@ from loguru import logger
 _red = "\033[0;31m"
 _nc = "\033[0m"
 
-VERSION = "0.2.0-rc.0"
+VERSION = "0.2.1"
 LOGO = """
                             ..............                            
                            .--------------. :                         

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "keystone-scim"
-version = "0.2.0-rc.0"
+version = "0.2.1"
 description = "A SCIM 2.0 Provisioning API"
 authors = ["Yuval Herziger <yherziger@microsoft.com>"]
 license = "MIT"


### PR DESCRIPTION
Some SQLAlchemy queries in the RDBMS stores (PostgreSQL & MySQL) could use more responsible parameterizations.  While they weren't prone to SQL injections in their previous state, using SQLAlchemy's built-in query parameterization is significantly safer.

